### PR TITLE
Release 2.3.6

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.3.6 (2021-10-20)
+------------------
+
+* Use alpha column rather than 1 - interval_size in sequential tests to allow for different alphas for different dimensions
+
 2.3.5 (2021-10-19)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ dist: clean ## builds source and wheel packagels
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	pip install .
+	pip install -e .
 
 install-test: clean
 	pip3 install --index-url https://test.pypi.org/simple/ confidence-spotify

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Spotify Confidence
 ========
 
 ![Status](https://img.shields.io/badge/Status-Beta-blue.svg)
-![Latest release](https://img.shields.io/badge/release-2.3.5-green.svg "Latest release: 2.3.5")
+![Latest release](https://img.shields.io/badge/release-2.3.6-green.svg "Latest release: 2.3.6")
 ![Python](https://img.shields.io/badge/Python-3.6-blue.svg "Python")
 ![Python](https://img.shields.io/badge/Python-3.7-blue.svg "Python")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spotify-confidence
-version = 2.3.5
+version = 2.3.6
 author = Per Sillren
 author_email = pers@spotify.com
 description = Package for calculating and visualising confidence intervals, e.g. for A/B test analysis.

--- a/spotify_confidence/analysis/frequentist/statsmodels_computer.py
+++ b/spotify_confidence/analysis/frequentist/statsmodels_computer.py
@@ -666,6 +666,7 @@ class ZTestComputer(StatsmodelsComputer):
 
         groupby = ['level_1', 'level_2'] + groups_except_ordinal
         num_comparisons = self._get_num_comparisons(df, self._correction_method, groupby)
+
         def adjusted_alphas_for_group(grp) -> Series:
             return (
                 sequential_bounds(

--- a/tests/frequentist/test_ztest.py
+++ b/tests/frequentist/test_ztest.py
@@ -1815,7 +1815,7 @@ class TestSequentialOrdinalPlusTwoCategorical2(object):
                 .groupby([GROUP, 'country', 'platform', 'metric']).cumsum()
                 .reset_index()
                 .assign(non_inferiority_margin=lambda df: df['metric'].map(
-                    {'bananas_per_user_1d': 0, 'bananas_per_user_7d': 0.01}))
+                    {'bananas_per_user_1d': None, 'bananas_per_user_7d': 0.01}))
                 .assign(preferred_direction=lambda df: df['metric'].map(
                     {'bananas_per_user_1d': None, 'bananas_per_user_7d': 'increase'}))
                 .assign(final_expected_sample_size=5000)


### PR DESCRIPTION
- Use alpha from df column instead of 1-intervall size to capture alpha correction for certain multiple correction methods
- Change makefile to Install locally with -e flag to simplify local testing