### PR TITLE
Fix default value for parameter `level_as_reference`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.7.1 (2022-08-08)
+------------------
+
+* Bug fix for calculating relative NIMs/MDEs with variance reduction.
+
 2.7.0 (2022-05-17)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Spotify Confidence
 ========
 
 ![Status](https://img.shields.io/badge/Status-Beta-blue.svg)
-![Latest release](https://img.shields.io/badge/release-2.7.0-green.svg "Latest release: 2.7.0")
+![Latest release](https://img.shields.io/badge/release-2.7.1-green.svg "Latest release: 2.7.1")
 ![Python](https://img.shields.io/badge/Python-3.6-blue.svg "Python")
 ![Python](https://img.shields.io/badge/Python-3.7-blue.svg "Python")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spotify-confidence
-version = 2.7.0
+version = 2.7.1
 author = Per Sillren
 author_email = pers@spotify.com
 description = Package for calculating and visualising confidence intervals, e.g. for A/B test analysis.

--- a/spotify_confidence/analysis/abstract_base_classes/confidence_abc.py
+++ b/spotify_confidence/analysis/abstract_base_classes/confidence_abc.py
@@ -173,7 +173,7 @@ class ConfidenceABC(ABC):
                 If specified, will plot a separate chart for each level of the
                 grouping.
             level_as_reference (bool):
-                If false (default), compare level to all other
+                If false, compare level to all other
                 groups. If true, compare all other groups to level.
             non_inferiority_margins (Union[Tuple[float, str],
                     Dict[str, Tuple[float, str]]]):
@@ -356,7 +356,7 @@ class ConfidenceABC(ABC):
                 If specified, will return an interval for each level
                 of the grouped dimension, or a confidence band if the
                 grouped dimension is ordinal
-            level_as_reference: If false (default), compare level to all other
+            level_as_reference: If false, compare level to all other
              groups. If true, compare all other groups to level.
             non_inferiority_margins (Union[Tuple[float, str],
                     Dict[str, Tuple[float, str]]]):

--- a/spotify_confidence/analysis/bayesian/bayesian_base.py
+++ b/spotify_confidence/analysis/bayesian/bayesian_base.py
@@ -391,7 +391,7 @@ class BaseTest(object, metaclass=ABCMeta):
                 If specified, will return an interval for each level
                 of the grouped dimension, or a confidence band if the
                 grouped dimension is ordinal
-            level_as_reference: If false (default), compare level to all other
+            level_as_reference: If false, compare level to all other
              groups. If true, compare all other groups to level.
         """
         use_ordinal_axis = self._use_ordinal_axis(groupby)

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -409,7 +409,7 @@ class GenericComputer(ConfidenceComputerABC):
         mde_column: str,
     ):
         if type(level_as_reference) is not bool:
-            raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
+            raise ValueError(f"level_as_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])
         validate_levels(self._sufficient_statistics, level_columns, unique_levels)

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -488,6 +488,7 @@ class GenericComputer(ConfidenceComputerABC):
                 mde_column=mde_column,
                 nim_column=NIM_COLUMN_DEFAULT,
                 preferred_direction_column=PREFERRED_DIRECTION_COLUMN_DEFAULT,
+                method_column=self._method_column,
             )
             .pipe(join)
             .query(
@@ -784,7 +785,9 @@ def add_nim_input_columns_from_tuple_or_dict(df, nims: NIM_TYPE, mde_column: str
         return df
 
 
-def add_nims_and_mdes(df: DataFrame, mde_column: str, nim_column: str, preferred_direction_column: str) -> DataFrame:
+def add_nims_and_mdes(
+    df: DataFrame, mde_column: str, nim_column: str, preferred_direction_column: str, method_column: str = None
+) -> DataFrame:
     def _set_nims_and_mdes(grp: DataFrame) -> DataFrame:
         nim = grp[nim_column].astype(float)
         input_preference = grp[preferred_direction_column].values[0]
@@ -792,18 +795,23 @@ def add_nims_and_mdes(df: DataFrame, mde_column: str, nim_column: str, preferred
 
         nim_is_na = nim.isna().all()
         mde_is_na = True if mde is None else mde.isna().all()
+        estimate_column = (
+            ORIGINAL_POINT_ESTIMATE
+            if method_column is not None and (grp[method_column] == ZTESTLINREG).all()
+            else POINT_ESTIMATE
+        )
         if input_preference is None or (type(input_preference) is float and isnan(input_preference)):
-            signed_nim = 0.0 if nim_is_na else nim * grp[POINT_ESTIMATE]
+            signed_nim = 0.0 if nim_is_na else nim * grp[estimate_column]
             preference = TWO_SIDED
-            signed_mde = None if mde_is_na else mde * grp[POINT_ESTIMATE]
+            signed_mde = None if mde_is_na else mde * grp[estimate_column]
         elif input_preference.lower() == INCREASE_PREFFERED:
-            signed_nim = 0.0 if nim_is_na else -nim * grp[POINT_ESTIMATE]
+            signed_nim = 0.0 if nim_is_na else -nim * grp[estimate_column]
             preference = "larger"
-            signed_mde = None if mde_is_na else mde * grp[POINT_ESTIMATE]
+            signed_mde = None if mde_is_na else mde * grp[estimate_column]
         elif input_preference.lower() == DECREASE_PREFFERED:
-            signed_nim = 0.0 if nim_is_na else nim * grp[POINT_ESTIMATE]
+            signed_nim = 0.0 if nim_is_na else nim * grp[estimate_column]
             preference = "smaller"
-            signed_mde = None if mde_is_na else -mde * grp[POINT_ESTIMATE]
+            signed_mde = None if mde_is_na else -mde * grp[estimate_column]
         else:
             raise ValueError(f"{input_preference.lower()} not in " f"{[INCREASE_PREFFERED, DECREASE_PREFFERED]}")
 
@@ -926,14 +934,18 @@ def _add_p_value_and_ci(df: DataFrame, arg_dict: Dict) -> DataFrame:
     def _add_ci(df: DataFrame, arg_dict: Dict) -> DataFrame:
         lower, upper = confidence_computers[df[arg_dict[METHOD]].values[0]].ci(df, ALPHA, arg_dict)
 
-        if arg_dict[CORRECTION_METHOD] in [
-            HOLM,
-            HOMMEL,
-            SIMES_HOCHBERG,
-            SPOT_1_HOLM,
-            SPOT_1_HOMMEL,
-            SPOT_1_SIMES_HOCHBERG,
-        ] and all(df[PREFERENCE_TEST] != TWO_SIDED):
+        if (
+            arg_dict[CORRECTION_METHOD]
+            in [
+                HOLM,
+                HOMMEL,
+                SIMES_HOCHBERG,
+                SPOT_1_HOLM,
+                SPOT_1_HOMMEL,
+                SPOT_1_SIMES_HOCHBERG,
+            ]
+            and all(df[PREFERENCE_TEST] != TWO_SIDED)
+        ):
             if all(df[arg_dict[METHOD]] == "z-test"):
                 adjusted_lower, adjusted_upper = confidence_computers["z-test"].ci_for_multiple_comparison_methods(
                     df, arg_dict[CORRECTION_METHOD], alpha=1 - arg_dict[INTERVAL_SIZE]

--- a/spotify_confidence/analysis/frequentist/experiment.py
+++ b/spotify_confidence/analysis/frequentist/experiment.py
@@ -162,7 +162,7 @@ class Experiment(ConfidenceABC):
         level: Union[str, Tuple],
         absolute: bool = True,
         groupby: Union[str, Iterable] = None,
-        level_as_reference: bool = None,
+        level_as_reference: bool = False,
         non_inferiority_margins: NIM_TYPE = None,
         final_expected_sample_size_column: str = None,
         verbose: bool = False,

--- a/tests/frequentist/test_ttest.py
+++ b/tests/frequentist/test_ttest.py
@@ -91,7 +91,7 @@ class TestCategorical(object):
         sigma2 = 2
         x2 = np.random.normal(mu2, sigma2, n2)
 
-        std_diff = np.sqrt(sigma1**2 / n1 + sigma2**2 / n2)
+        std_diff = np.sqrt(sigma1 ** 2 / n1 + sigma2 ** 2 / n2)
 
         arg_dict = {DENOMINATOR: "n"}
         diff_se = computer.std_err(

--- a/tests/frequentist/test_ztest_linreg.py
+++ b/tests/frequentist/test_ztest_linreg.py
@@ -15,8 +15,8 @@ class TestUnivariateSingleMetric(object):
         data = pd.DataFrame({"variation_name": list(map(str, d)), "y": y, "x": x})
         data = (
             data.assign(xy=y * x)
-            .assign(x2=x**2)
-            .assign(y2=y**2)
+            .assign(x2=x ** 2)
+            .assign(y2=y ** 2)
             .groupby(["variation_name"])
             .agg({"y": ["sum", "count"], "y2": "sum", "x": "sum", "x2": "sum", "xy": "sum"})
             .reset_index()
@@ -83,8 +83,8 @@ class TestUnivariateMultiMetric(object):
         data = pd.DataFrame({"variation_name": list(map(str, d)), "metric_name": m, "y": y, "x": x})
         data = (
             data.assign(xy=y * x)
-            .assign(x2=x**2)
-            .assign(y2=y**2)
+            .assign(x2=x ** 2)
+            .assign(y2=y ** 2)
             .groupby(["variation_name", "metric_name"])
             .agg({"y": ["sum", "count"], "y2": "sum", "x": "sum", "x2": "sum", "xy": "sum"})
             .reset_index()
@@ -226,7 +226,7 @@ class TestMultivariateSingleMetric(object):
         y = 0.5 * d + 0.5 * x1 + 0.5 * x2 + np.random.standard_normal(size=n)
         df = pd.DataFrame({"variation_name": list(map(str, d)), "y": y, "x1": x1, "x2": x2})
 
-        data = df.assign(y2=y**2).groupby(["variation_name"]).agg({"y": ["sum", "count"], "y2": "sum"}).reset_index()
+        data = df.assign(y2=y ** 2).groupby(["variation_name"]).agg({"y": ["sum", "count"], "y2": "sum"}).reset_index()
 
         data.columns = data.columns.map("_".join).str.strip("_")
 
@@ -332,7 +332,7 @@ class TestMultivariateMultipleMetrics(object):
         )
 
         data = (
-            df.assign(y2=y**2)
+            df.assign(y2=y ** 2)
             .groupby(["variation_name", "metric_name"])
             .agg({"y": ["sum", "count"], "y2": "sum"})
             .reset_index()


### PR DESCRIPTION
The default value of parameter `level_as_reference` is currently set to `None`, but I believe the value should be `False`, in the following method:

`spotify_confidence.analysis.frequentist.experiment.Experiment.multiple_difference`

The default is specified in the docstring of `multiple_difference`:

```
    level_as_reference (bool):
        If false (default), compare level to all other
        groups. If true, compare all other groups to level.
```

This should address issue #61. 