### PR TITLE
Fix for unhashable levels

### DIFF
--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -411,7 +411,7 @@ class GenericComputer(ConfidenceComputerABC):
         if type(level_as_reference) is not bool:
             raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
-        levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents is hashable
+        levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents are hashable
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])
         validate_levels(self._sufficient_statistics, level_columns, unique_levels)
         str2level = {level2str(lv): lv for lv in unique_levels}

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -411,6 +411,7 @@ class GenericComputer(ConfidenceComputerABC):
         if type(level_as_reference) is not bool:
             raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
+        levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents is hashable
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])
         validate_levels(self._sufficient_statistics, level_columns, unique_levels)
         str2level = {level2str(lv): lv for lv in unique_levels}

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -411,8 +411,6 @@ class GenericComputer(ConfidenceComputerABC):
         if type(level_as_reference) is not bool:
             raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
-        print("levels:")
-        print(levels)
         if type(levels[0][0]) != str:
             levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents are hashable
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -411,7 +411,10 @@ class GenericComputer(ConfidenceComputerABC):
         if type(level_as_reference) is not bool:
             raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
-        levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents are hashable
+        print("levels:")
+        print(levels)
+        if type(levels[0][0]) != str:
+            levels = [tuple([tuple(l) for l in levels[0]])] # ensure contents are hashable
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])
         validate_levels(self._sufficient_statistics, level_columns, unique_levels)
         str2level = {level2str(lv): lv for lv in unique_levels}


### PR DESCRIPTION
This fixes an issue where running difference() with levels that are specified as type list throws an error: `TypeError: unhashable type: 'list'`. The fix used here casts the contents of levels to tuples, allowing list or tuple to be used by the user in the `difference` method (since tuple is working fine as is).

This PR should address issue https://github.com/spotify/confidence/issues/63.