### PR TITLE
Fix default value for parameter level_as_reference - v2

### DIFF
--- a/spotify_confidence/analysis/abstract_base_classes/confidence_abc.py
+++ b/spotify_confidence/analysis/abstract_base_classes/confidence_abc.py
@@ -173,7 +173,7 @@ class ConfidenceABC(ABC):
                 If specified, will plot a separate chart for each level of the
                 grouping.
             level_as_reference (bool):
-                If false (default), compare level to all other
+                If false, compare level to all other
                 groups. If true, compare all other groups to level.
             non_inferiority_margins (Union[Tuple[float, str],
                     Dict[str, Tuple[float, str]]]):
@@ -356,7 +356,7 @@ class ConfidenceABC(ABC):
                 If specified, will return an interval for each level
                 of the grouped dimension, or a confidence band if the
                 grouped dimension is ordinal
-            level_as_reference: If false (default), compare level to all other
+            level_as_reference: If false, compare level to all other
              groups. If true, compare all other groups to level.
             non_inferiority_margins (Union[Tuple[float, str],
                     Dict[str, Tuple[float, str]]]):

--- a/spotify_confidence/analysis/bayesian/bayesian_base.py
+++ b/spotify_confidence/analysis/bayesian/bayesian_base.py
@@ -391,7 +391,7 @@ class BaseTest(object, metaclass=ABCMeta):
                 If specified, will return an interval for each level
                 of the grouped dimension, or a confidence band if the
                 grouped dimension is ordinal
-            level_as_reference: If false (default), compare level to all other
+            level_as_reference: If false, compare level to all other
              groups. If true, compare all other groups to level.
         """
         use_ordinal_axis = self._use_ordinal_axis(groupby)

--- a/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py
@@ -409,7 +409,7 @@ class GenericComputer(ConfidenceComputerABC):
         mde_column: str,
     ):
         if type(level_as_reference) is not bool:
-            raise ValueError(f"level_is_reference must be either True or False, but is {level_as_reference}.")
+            raise ValueError(f"level_as_reference must be either True or False, but is {level_as_reference}.")
         groupby = listify(groupby)
         unique_levels = set([l[0] for l in levels] + [l[1] for l in levels])
         validate_levels(self._sufficient_statistics, level_columns, unique_levels)

--- a/spotify_confidence/analysis/frequentist/experiment.py
+++ b/spotify_confidence/analysis/frequentist/experiment.py
@@ -233,7 +233,7 @@ class Experiment(ConfidenceABC):
         level: Union[str, Tuple],
         absolute: bool = True,
         groupby: Union[str, Iterable] = None,
-        level_as_reference: bool = False,
+        level_as_reference: bool = None,
         non_inferiority_margins: NIM_TYPE = None,
         use_adjusted_intervals: bool = False,
         final_expected_sample_size_column: str = None,

--- a/spotify_confidence/analysis/frequentist/experiment.py
+++ b/spotify_confidence/analysis/frequentist/experiment.py
@@ -162,7 +162,7 @@ class Experiment(ConfidenceABC):
         level: Union[str, Tuple],
         absolute: bool = True,
         groupby: Union[str, Iterable] = None,
-        level_as_reference: bool = None,
+        level_as_reference: bool = False,
         non_inferiority_margins: NIM_TYPE = None,
         final_expected_sample_size_column: str = None,
         verbose: bool = False,

--- a/spotify_confidence/analysis/frequentist/experiment.py
+++ b/spotify_confidence/analysis/frequentist/experiment.py
@@ -162,7 +162,7 @@ class Experiment(ConfidenceABC):
         level: Union[str, Tuple],
         absolute: bool = True,
         groupby: Union[str, Iterable] = None,
-        level_as_reference: bool = False,
+        level_as_reference: bool = None,
         non_inferiority_margins: NIM_TYPE = None,
         final_expected_sample_size_column: str = None,
         verbose: bool = False,


### PR DESCRIPTION
## Summary

This PR is meant to replace PR #62 and address Issue #61. 

Per the discussion in PR #62, I set the default value of `level_as_reference` back to `None`, but kept the docstring edits. 

## Reference - Current Default Values

@iampelle I am actually not sure what the strategy for `level_as_reference` default values is (e.g. where to use True, False, or None), so I am leaving that out currently. Please feel free to take that over if it's easier (perhaps as a separate issue/PR), or else if more information is provided I'm happy to work on it further. 

Below are my findings for current default values. The file name is shown on the left, and default value on the right. Note that in some cases, the same file has different default values used in different places (e.g. in different methods). 

Here `False` is the default:

```
spotify_confidence/analysis/frequentist/experiment.py:        level_as_reference: bool = False,
spotify_confidence/analysis/bayesian/bayesian_models.py:    def multiple_difference(self, level, absolute=True, groupby=None, level_as_reference=False):
spotify_confidence/analysis/bayesian/bayesian_base.py:    def multiple_difference(self, level, absolute=True, groupby=None, level_as_reference=False):
spotify_confidence/analysis/bayesian/bayesian_base.py:    def multiple_difference_plot(self, level, absolute=True, groupby=None, level_as_reference=False):
```

And, here is where `True` is being used:

```
spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py:            level_as_reference=True,
spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py:            level_as_reference=True,
spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py:                level_as_reference=True,
```

And as discussed earlier, `None` is used here:

`spotify_confidence/analysis/frequentist/experiment.py:        level_as_reference: bool = None,`