### PR TITLE
Fixes multiple issues related to sequential testing

### DIFF
--- a/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
@@ -520,7 +520,9 @@ class ConfidenceComputer(ConfidenceComputerABC):
             NUMBER_OF_COMPARISONS: n_comparisons,
         }
         comparison_df = groupbyApplyParallel(
-            comparison_df.groupby(groups_except_ordinal + [self._method_column], as_index=False, sort=False),
+            comparison_df.groupby(
+                groups_except_ordinal + [self._method_column, "level_1", "level_2"], as_index=False, sort=False
+            ),
             lambda df: _compute_comparisons(df, arg_dict=arg_dict),
         )
         return comparison_df

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
@@ -121,6 +121,8 @@ def compute_sequential_adjusted_alpha(df: DataFrame, arg_dict: Dict[str, str]):
     ordinal_group_column = arg_dict[ORDINAL_GROUP_COLUMN]
     n_comparisons = arg_dict[NUMBER_OF_COMPARISONS]
 
+    _check_valid_sequential_df(df, ordinal_group_column)
+
     def adjusted_alphas_for_group(grp: DataFrame) -> Series:
         return (
             sequential_bounds(
@@ -141,33 +143,20 @@ def compute_sequential_adjusted_alpha(df: DataFrame, arg_dict: Dict[str, str]):
             )
         )[["zb", ADJUSTED_ALPHA]]
 
-    groups_except_ordinal = [column for column in df.index.names if column != ordinal_group_column]
-    max_sample_size_by_group = (
-        (
-            df[["current_total_" + denominator, final_expected_sample_size_column]]
-            .groupby(groups_except_ordinal, sort=False)
-            .max()
-            .max(axis=1)
-        )
-        if len(groups_except_ordinal) > 0
-        else (df[["current_total_" + denominator, final_expected_sample_size_column]].max().max())
-    )
-    sample_size_proportions = Series(
-        data=df.groupby(df.index.names, sort=False)["current_total_" + denominator].first() / max_sample_size_by_group,
-        name="sample_size_proportions",
-    )
+    comparison_total_column = "comparison_total_" + denominator
+    df[comparison_total_column] = df[denominator + SFX1] + df[denominator + SFX2]
+    df["max_sample_size"] = df[[comparison_total_column, final_expected_sample_size_column]].max(axis=1)
+    df["sample_size_proportions"] = df[comparison_total_column] / df["max_sample_size"]
 
     return Series(
-        data=df.groupby(df.index.names, sort=False, group_keys=True)[[ALPHA, PREFERENCE_TEST]]
-        .first()
-        .merge(sample_size_proportions, left_index=True, right_index=True)
-        .assign(_sequential_dummy_index_=1)
-        .groupby(groups_except_ordinal + ["_sequential_dummy_index_"], sort=False)[
-            ["sample_size_proportions", PREFERENCE_TEST, ALPHA]
-        ]
-        .apply(adjusted_alphas_for_group)[ADJUSTED_ALPHA],
+        data=df.pipe(adjusted_alphas_for_group)[ADJUSTED_ALPHA],
         name=ADJUSTED_ALPHA,
     )
+
+
+def _check_valid_sequential_df(df, ordinal_group_column):
+    if not df.reset_index()[ordinal_group_column].is_unique:
+        raise ValueError("Ordinal values cannot be duplicated")
 
 
 def ci_for_multiple_comparison_methods(

--- a/tests/frequentist/test_ztest.py
+++ b/tests/frequentist/test_ztest.py
@@ -3450,6 +3450,51 @@ class TestSequentialTwoSided(object):
         np.testing.assert_almost_equal(difference_df[DIFFERENCE].values[0], -0.0149, 3)
 
 
+class TestSequentialOneSidedThreeGroups(object):
+    def setup(self):
+        DATE = "date"
+        COUNT = "count"
+        SUM = "sum"
+        SUM_OF_SQUARES = "sum_of_squares"
+        GROUP = "group"
+
+        self.data = pd.DataFrame(
+            [
+                {DATE: 1, GROUP: "1", COUNT: 500, SUM: 1000, SUM_OF_SQUARES: 3000},
+                {DATE: 1, GROUP: "2", COUNT: 1000, SUM: 1000, SUM_OF_SQUARES: 6000},
+                {DATE: 1, GROUP: "3", COUNT: 1500, SUM: 1000, SUM_OF_SQUARES: 12000},
+                {DATE: 2, GROUP: "1", COUNT: 1000, SUM: 2000, SUM_OF_SQUARES: 6000},
+                {DATE: 2, GROUP: "2", COUNT: 2000, SUM: 2000, SUM_OF_SQUARES: 12000},
+                {DATE: 2, GROUP: "3", COUNT: 3000, SUM: 2000, SUM_OF_SQUARES: 24000},
+            ]
+        ).assign(final_expected_sample_size=1e4)
+
+        self.test = spotify_confidence.ZTest(
+            self.data,
+            numerator_column=SUM,
+            numerator_sum_squares_column=SUM_OF_SQUARES,
+            denominator_column=COUNT,
+            categorical_group_columns=[DATE],
+            ordinal_group_column=DATE,
+            treatment_column=GROUP,
+            interval_size=0.95,
+        )
+
+    def test_multiple_difference_groupby(self):
+        difference_df = self.test.multiple_difference(
+            level="1",
+            groupby="date",
+            level_as_reference=True,
+            final_expected_sample_size_column="final_expected_sample_size",
+        )
+
+        test_df = difference_df.reset_index().sort_values(["level_2", "date"])
+        np.testing.assert_almost_equal(test_df[ADJUSTED_LOWER].values, [-1.327445, -1.209182, -1.646339, -1.531049], 3)
+        np.testing.assert_almost_equal(
+            test_df[ADJUSTED_UPPER].values, [-0.6725549, -0.7908185, -1.0203281, -1.1356181], 3
+        )
+
+
 class TestNimsWithNaN(object):
     def setup(self):
         self.data = pd.DataFrame(


### PR DESCRIPTION
# Summary
Fixes the following issues with GST:

* Data frame was not grouped on the groups that are compared, causing
  GST to silently replace the confidence limits of latter groups with
  the first when you had more than two groups.
* The sample size for GST was too big due to aggregation over groups, causing
  information rate to be too high, increasing false positive rates.
* The total sample size for GST was aggregated over all comparisons,
  making it larger than necessary causing the test to be unnecessarily
  conservative.

# Details
## GST overwrites intervals for multiple groups
The following line:
https://github.com/spotify/confidence/blob/f72c4475f03ab753384267f3f952debd98a14971/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py#L161-L162

causes the other groups to be discarded and then
https://github.com/spotify/confidence/blob/f72c4475f03ab753384267f3f952debd98a14971/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py#L912

joins on an index that doesn't contain the group, so it joins the same data multiple times to the other groups on the left hand side.

## Observed sample size too big
The sample size calculation incorrectly aggregates over groups
https://github.com/spotify/confidence/blob/f72c4475f03ab753384267f3f952debd98a14971/spotify_confidence/analysis/frequentist/confidence_computers/generic_computer.py#L464-L469

causing a too big information ratio here:
https://github.com/spotify/confidence/blob/f72c4475f03ab753384267f3f952debd98a14971/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py#L156

leading to an increased false positive rate, because the bounds now think they had bigger sample size than they actually had.

## Total sample size too big
The following lines:
https://github.com/spotify/confidence/blob/f72c4475f03ab753384267f3f952debd98a14971/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py#L147-L150

takes the maximum over all groups, but for GST to work correctly, we only need the maximum per comparison, making it have a too big max sample size, making it unnecessarily conservative.

# Summary of changes

* Added "group" to the *first* groupby in confidence, so that all statistics are computed per group, ensuring that any joins based on index will not explode.
* Changed GST information rate calculation to only consider one comparison.
* Changed GST to assume and verify that the passed data frame only contains samples for one group.

# R-script for computing GST bounds for test cases
Short script to verify confidence implementation in an second language:

```r
library(dplyr)

compute_bounds = function(t.info, n.comp) {
  bounds = ldBounds(t.info, iuse=3, alpha=0.05/n.comp, phi=2, sides=2, ztrun=rep(8, length(t.info)))
  
  return(data.frame(
    lower = bounds$lower.bounds,
    upper = bounds$upper.bounds
  ))
}

max_n = 10000
df = data.frame(
  group = c(1, 2, 3, 1, 2, 3),
  t = c(1, 1, 1, 2, 2, 2),
  count = c(500, 1000, 1500, 1000, 2000, 3000),
  sum = c(1000, 1000, 1000, 2000, 2000, 2000),
  sos = c(3000, 6000, 12000, 6000, 12000, 24000)
) %>%
  mutate(mu=sum/count, sigma2=(count/(count -1))*(sos/count - (sum/count)^2)) %>%
  arrange(group, t)

comparison_df = df %>%
  inner_join(df, by = "t") %>% 
  filter(group.x == 1 & group.x != group.y) %>%
  mutate(tau = mu.y - mu.x, n.comp=length(unique(group.y)),
         t.info = (count.x + count.y) / max_n,
         sigma_tau=sqrt(sigma2.x/count.x + sigma2.y/count.y)) %>%
  group_by(group.x, group.y) %>%
  summarize(across(), compute_bounds(t.info, n.comp[1])) %>%
  mutate(tau_lower=tau+lower*sigma_tau, tau_upper=tau+upper*sigma_tau)

res$tau_lower
res$tau_upper
```