### PR TITLE
Release 2.7.6

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+2.7.6 (2022-11-22)
+------------------
+* Fixed bug in compute_sequential_adjusted_alpha where we since 2.7.6 were taking the max sample size rowwise
+
 2.7.5 (2022-11-15)
 ------------------
 * Major refactoring, splitting the code into more files for improved readability

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Spotify Confidence
 ========
 
 ![Status](https://img.shields.io/badge/Status-Beta-blue.svg)
-![Latest release](https://img.shields.io/badge/release-2.7.5-green.svg "Latest release: 2.7.5")
+![Latest release](https://img.shields.io/badge/release-2.7.6-green.svg "Latest release: 2.7.6")
 ![Python](https://img.shields.io/badge/Python-3.6-blue.svg "Python")
 ![Python](https://img.shields.io/badge/Python-3.7-blue.svg "Python")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spotify-confidence
-version = 2.7.5
+version = 2.7.6
 author = Per Sillren
 author_email = pers@spotify.com
 description = Package for calculating and visualising confidence intervals, e.g. for A/B test analysis.

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
@@ -149,7 +149,9 @@ def compute_sequential_adjusted_alpha(df: DataFrame, arg_dict: Dict[str, str]):
         data=(
             df.assign(**{comparison_total_column: df[denominator + SFX1] + df[denominator + SFX2]})
             .assign(
-                max_sample_size=lambda df: df[[comparison_total_column, final_expected_sample_size_column]].max(axis=1)
+                max_sample_size=lambda df: df[[comparison_total_column, final_expected_sample_size_column]]
+                .max(axis=1)
+                .max()
             )
             .assign(sample_size_proportions=lambda df: df[comparison_total_column] / df["max_sample_size"])
             .pipe(adjusted_alphas_for_group)[ADJUSTED_ALPHA]


### PR DESCRIPTION
* Fixed bug in compute_sequential_adjusted_alpha where we since 2.7.6 were taking the max sample size rowwise