### PR TITLE
Release 2.7.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.7.7 (2023-01-21)
+------------------
+* Fixed bug that led to unexpected behaviour when using non_inferiority_margins=False. Not passing False produces the same result as passing None
+* Fixed bug in chartify grpaher that caused a crash when attempting to plot a mix of metrics where only some had non-inferiority margins
+
 2.7.6 (2022-11-22)
 ------------------
 * Fixed bug in compute_sequential_adjusted_alpha where we since 2.7.6 were taking the max sample size rowwise

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 2.7.7 (2023-01-21)
 ------------------
 * Fixed bug that led to unexpected behaviour when using non_inferiority_margins=False. Not passing False produces the same result as passing None
-* Fixed bug in chartify grpaher that caused a crash when attempting to plot a mix of metrics where only some had non-inferiority margins
+* Fixed bug in chartify grapher that caused a crash when attempting to plot a mix of metrics where only some had non-inferiority margins
 
 2.7.6 (2022-11-22)
 ------------------

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ Spotify Confidence
 ========
 
 ![Status](https://img.shields.io/badge/Status-Beta-blue.svg)
-![Latest release](https://img.shields.io/badge/release-2.7.6-green.svg "Latest release: 2.7.6")
+![Latest release](https://img.shields.io/badge/release-2.7.7-green.svg "Latest release: 2.7.6")
 ![Python](https://img.shields.io/badge/Python-3.6-blue.svg "Python")
 ![Python](https://img.shields.io/badge/Python-3.7-blue.svg "Python")
+![Python](https://img.shields.io/badge/Python-3.8-blue.svg "Python")
+![Python](https://img.shields.io/badge/Python-3.9-blue.svg "Python")
 
 Python library for AB test analysis.
 
@@ -18,7 +20,8 @@ Each function comes in two versions:
  - one that returns a [Chartify](https://github.com/spotify/chartify) chart.
 
 Spotify Confidence has support calculating p-values and confidence intervals using Z-statistics, Student's T-statistics 
-(or more exactly [Welch's T-test](https://en.wikipedia.org/wiki/Welch%27s_t-test)), as well as Chi-squared statistics.
+(or more exactly [Welch's T-test](https://en.wikipedia.org/wiki/Welch%27s_t-test)), as well as Chi-squared statistics. 
+It also supports a variance reduction technique based on using pre-exposure data to fit a linear model.  
 
 There is also a Bayesian alternative in the BetaBinomial class.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spotify-confidence
-version = 2.7.6
+version = 2.7.7
 author = Per Sillren
 author_email = pers@spotify.com
 description = Package for calculating and visualising confidence intervals, e.g. for A/B test analysis.

--- a/spotify_confidence/analysis/frequentist/chartify_grapher.py
+++ b/spotify_confidence/analysis/frequentist/chartify_grapher.py
@@ -268,7 +268,7 @@ class ChartifyGrapher(ConfidenceGrapherABC):
         ch.figure.circle(
             source=df, x="categorical_x", y=DIFFERENCE, size=20, name="center", line_alpha=0, fill_alpha=0
         )
-        if NULL_HYPOTHESIS in df.columns:
+        if NULL_HYPOTHESIS in df.columns and df[NIM].notna().any():
             ch.style.color_palette.reset_palette_order()
             dash_source = (
                 df[~df[NIM].isna()]

--- a/spotify_confidence/analysis/frequentist/nims_and_mdes.py
+++ b/spotify_confidence/analysis/frequentist/nims_and_mdes.py
@@ -26,7 +26,7 @@ def add_nim_input_columns_from_tuple_or_dict(df, nims: NIM_TYPE, mde_column: str
         return df.assign(**{NIM_COLUMN_DEFAULT: lambda df: df.index.to_series().map(nim_values)}).assign(
             **{PREFERRED_DIRECTION_COLUMN_DEFAULT: lambda df: df.index.to_series().map(nim_preferences)}
         )
-    elif nims is None:
+    elif nims is None or not nims:
         return df.assign(**{NIM_COLUMN_DEFAULT: None}).assign(
             **{
                 PREFERRED_DIRECTION_COLUMN_DEFAULT: None

--- a/tests/frequentist/test_experiment.py
+++ b/tests/frequentist/test_experiment.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pandas as pd
+import pytest
+from contextlib import nullcontext as does_not_raise
 
 import spotify_confidence
-from spotify_confidence.analysis.constants import METHOD_COLUMN_NAME, ZTEST
+from spotify_confidence.analysis.constants import METHOD_COLUMN_NAME, ZTEST, ADJUSTED_LOWER, ADJUSTED_UPPER
 
 
 class TestBootstrap(object):
@@ -146,3 +148,92 @@ class TestBootstrap(object):
         )
 
         assert len(diff) == 4
+
+    def test_multiple_differences_nims_false_none_true(self):
+        pd.options.display.max_columns = None
+        test = self.get_experiment_with_some_nims()
+
+        diff_nim_false = test.multiple_difference(
+            level="Control",
+            level_as_reference=True,
+            groupby="metric",
+            non_inferiority_margins=False,
+        )
+
+        diff_nim_none = test.multiple_difference(
+            level="Control",
+            level_as_reference=True,
+            groupby="metric",
+            non_inferiority_margins=None,
+        )
+
+        assert np.allclose(diff_nim_false[ADJUSTED_LOWER], diff_nim_none[ADJUSTED_LOWER])
+        assert np.allclose(diff_nim_false[ADJUSTED_UPPER], diff_nim_none[ADJUSTED_UPPER])
+
+        diff_nim_true = test.multiple_difference(
+            level="Control",
+            level_as_reference=True,
+            groupby="metric",
+            non_inferiority_margins=True,
+        )
+
+        assert np.all(diff_nim_true[ADJUSTED_LOWER] > diff_nim_none[ADJUSTED_LOWER])
+        assert np.all(diff_nim_true[ADJUSTED_UPPER] < diff_nim_none[ADJUSTED_UPPER])
+
+    @pytest.mark.parametrize(
+        "nims,expectation",
+        [
+            (False, does_not_raise()),
+            (None, does_not_raise()),
+            (True, does_not_raise()),
+        ],
+        ids=lambda x: f"non_inferiority_margins: {x}",
+    )
+    def test_multiple_differences_plot_adjusted_cis(self, nims, expectation):
+        pd.options.display.max_columns = None
+        test = self.get_experiment_with_some_nims()
+        with expectation:
+            ch = test.multiple_difference_plot(
+                level="Control",
+                level_as_reference=True,
+                groupby="metric",
+                absolute=True,
+                use_adjusted_intervals=True,
+                split_plot_by_groups=True,
+                non_inferiority_margins=nims,
+            )
+            assert len(ch.charts) > 0
+
+    def get_experiment_with_some_nims(self):
+        columns = [
+            "group_name",
+            "num_user",
+            "sum",
+            "sum_squares",
+            "method",
+            "metric",
+            "preferred_direction",
+            "non_inferiority_margin",
+        ]
+        data = [
+            ["Control", 6267728, 3240932, 3240932, "z-test", "m1", "increase", 0.15],
+            ["Test", 6260737, 3239706, 3239706, "z-test", "m1", "increase", 0.15],
+            ["Test", 6260737, 38600871, 12432573969, "z-test", "m2", "increase", None],
+            ["Control", 6267728, 35963863, 18433512959, "z-test", "m2", "increase", None],
+            ["Test", 6260737, 67382943, 8974188321, "z-test", "m3", "increase", None],
+            ["Control", 6267728, 67111374, 8728934960, "z-test", "m3", "increase", None],
+        ]
+        df = pd.DataFrame(columns=columns, data=data)
+        test = spotify_confidence.Experiment(
+            data_frame=df.assign(**{METHOD_COLUMN_NAME: ZTEST}),
+            numerator_column="sum",
+            numerator_sum_squares_column="sum_squares",
+            denominator_column="num_user",
+            categorical_group_columns="metric",
+            interval_size=0.99,
+            correction_method="spot-1-bonferroni",
+            metric_column="metric",
+            treatment_column="group_name",
+            method_column="method",
+        )
+        return test

--- a/tests/frequentist/test_experiment.py
+++ b/tests/frequentist/test_experiment.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from contextlib import nullcontext as does_not_raise
 
 import spotify_confidence
 from spotify_confidence.analysis.constants import METHOD_COLUMN_NAME, ZTEST, ADJUSTED_LOWER, ADJUSTED_UPPER
@@ -181,18 +180,18 @@ class TestBootstrap(object):
         assert np.all(diff_nim_true[ADJUSTED_UPPER] < diff_nim_none[ADJUSTED_UPPER])
 
     @pytest.mark.parametrize(
-        "nims,expectation",
+        "nims",
         [
-            (False, does_not_raise()),
-            (None, does_not_raise()),
-            (True, does_not_raise()),
+            False,
+            None,
+            True,
         ],
         ids=lambda x: f"non_inferiority_margins: {x}",
     )
-    def test_multiple_differences_plot_adjusted_cis(self, nims, expectation):
+    def test_multiple_differences_plot_some_nims_doesnt_raise_exception(self, nims):
         pd.options.display.max_columns = None
         test = self.get_experiment_with_some_nims()
-        with expectation:
+        try:
             ch = test.multiple_difference_plot(
                 level="Control",
                 level_as_reference=True,
@@ -203,6 +202,8 @@ class TestBootstrap(object):
                 non_inferiority_margins=nims,
             )
             assert len(ch.charts) > 0
+        except Exception as e:
+            assert False, f"Using non_inferiority_margins={nims} raised an exception: {e}."
 
     def get_experiment_with_some_nims(self):
         columns = [


### PR DESCRIPTION
* Fixed bug that led to unexpected behaviour when using non_inferiority_margins=False. Not passing False produces the same result as passing None

* Fixed bug in chartify grapher that caused a crash when attempting to plot a mix of metrics where only some had non-inferiority margins