### PR TITLE
Handle variance reduction with bad pre-exposure data

### DIFF
--- a/spotify_confidence/analysis/constants.py
+++ b/spotify_confidence/analysis/constants.py
@@ -58,6 +58,7 @@ OPTIMAL_WEIGHTS = "optimal_weigghts"
 ORIGINAL_POINT_ESTIMATE = "original_point_estimate"
 ORIGINAL_VARIANCE = "original_variance"
 VARIANCE_REDUCTION = "variance_reduction_rate"
+EQUAL_VARIANCE_PVALUE = "equal_variance_pvalue"
 
 BONFERRONI = "bonferroni"
 HOLM = "holm"

--- a/spotify_confidence/analysis/constants.py
+++ b/spotify_confidence/analysis/constants.py
@@ -58,7 +58,6 @@ OPTIMAL_WEIGHTS = "optimal_weigghts"
 ORIGINAL_POINT_ESTIMATE = "original_point_estimate"
 ORIGINAL_VARIANCE = "original_variance"
 VARIANCE_REDUCTION = "variance_reduction_rate"
-EQUAL_VARIANCE_PVALUE = "equal_variance_pvalue"
 
 BONFERRONI = "bonferroni"
 HOLM = "holm"

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_linreg_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_linreg_computer.py
@@ -42,7 +42,10 @@ def estimate_slope(df, arg_dict: Dict) -> DataFrame:
         col_sum(df[arg_dict[FEATURE_CROSS]])
     ).reshape(-1, 1)
 
-    b = np.matmul(np.linalg.inv(XX0), Xy0)
+    try:
+        b = np.matmul(np.linalg.inv(XX0), Xy0)
+    except np.linalg.LinAlgError:
+        b = np.zeros((k + 1, 1))
     out = b[1 : (k + 1)]
     if out.size == 1:
         out = out.item()

--- a/tests/frequentist/test_ztest_linreg.py
+++ b/tests/frequentist/test_ztest_linreg.py
@@ -512,5 +512,60 @@ class TestUnivariateMultiMetricRequiredSampleSize(object):
         )
 
 
-# TODO: Test for sequential data (w/ ordinal column)
-# TODO: Test for segmentation
+class TestUnivariateSingleMetricWithBadPreExposureData(object):
+    def setup(self):
+        np.random.seed(123)
+        n = 10000
+        d = np.random.randint(2, size=n)
+        y = 0.5 * d + np.random.standard_normal(size=n)
+        data = pd.DataFrame({"variation_name": list(map(str, d)), "y": y})
+        data = (
+            data
+            .assign(y2=y ** 2)
+            .groupby(["variation_name"])
+            .agg({"y": ["sum", "count"], "y2": "sum"})
+            .assign(**{"x_sum": 0.0, "x2_sum": 0.0, "xy_sum": 0.0})
+            .reset_index()
+        )
+
+        data.columns = data.columns.map("_".join).str.strip("_")
+        data = data.assign(**{"metric_name": "metricA"})
+        self.n = n
+        self.y = y
+        self.d = d
+        self.data = data
+
+        self.test = spotify_confidence.ZTestLinreg(
+            data_frame=data,
+            numerator_column="y_sum",
+            numerator_sum_squares_column="y2_sum",
+            denominator_column="y_count",
+            categorical_group_columns=["variation_name"],
+            feature_column="x_sum",
+            feature_sum_squares_column="x2_sum",
+            feature_cross_sum_column="xy_sum",
+            interval_size=0.99,
+            correction_method="bonferroni",
+            metric_column="metric_name",
+        )
+
+    def test_summary(self):
+        summary_df = self.test.summary(verbose=True)
+        print(summary_df)
+        assert len(summary_df) == len(self.data)
+
+    def test_parameters_univariate(self):
+
+        summary_df = self.test.summary(verbose=True)
+        assert np.allclose(0.0, summary_df[REGRESSION_PARAM][0], rtol=0.0001)
+
+        diff = self.test.difference(level_1="0", level_2="1", verbose=True, groupby="metric_name")
+        y = self.y
+        d = self.d
+        assert np.allclose(y[d == 1].mean() - y[d == 0].mean(), diff["difference"])
+
+        v0 = np.var(y[d == 0])
+        v1 = np.var(y[d == 1])
+        n0 = y[d == 0].size
+        n1 = y[d == 1].size
+        assert np.allclose(diff["std_err"], np.sqrt(v0 / n0 + v1 / n1), rtol=1e-3)


### PR DESCRIPTION
This PR introduces a behavior in which we revert to not using variance reduction if the pre-exposure data is "bad". Bad here means that the data matrix in the regression is not of full rank and hence not invertible. In the simplest of cases, this happens if there is a single covariate that has no variance. 