### PR TITLE
Fix other multiple correction methods than Bonferroni

### DIFF
--- a/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
@@ -493,7 +493,6 @@ class ConfidenceComputer(ConfidenceComputerABC):
             if column is not None
             and (column != self._ordinal_group_column or final_expected_sample_size_column is None)
         ]
-        print('groups_except_ordinal: ' + str(groups_except_ordinal))
         n_comparisons = get_num_comparisons(
             comparison_df,
             self._correction_method,
@@ -525,9 +524,10 @@ class ConfidenceComputer(ConfidenceComputerABC):
             ),
             lambda df: _compute_comparisons(df, **kwargs),
         )
-        #comparison_df = (comparison_df.pipe(add_adjusted_p_and_is_significant, **kwargs)
-        #                              .pipe(add_ci, **kwargs)
-        #                              .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE]))
+        
+        comparison_df = (comparison_df.pipe(add_adjusted_p_and_is_significant, **kwargs)
+                                      .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE])
+                                      .pipe(add_ci, **kwargs))
 
         return comparison_df
 
@@ -564,7 +564,6 @@ def _compute_comparisons(df: DataFrame, **kwargs: Dict) -> DataFrame:
         .assign(**{STD_ERR: confidence_computers[df[kwargs[METHOD]].values[0]].std_err(df, **kwargs)})
         .pipe(_add_p_value_and_ci, **kwargs)
         .pipe(_powered_effect_and_required_sample_size_from_difference_df, **kwargs)
-        .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE]) # remove?
         .assign(**{PREFERENCE: lambda df: df[PREFERENCE].map(PREFERENCE_DICT)})
         .pipe(_add_variance_reduction_rate, **kwargs)
     )
@@ -589,8 +588,6 @@ def _add_p_value_and_ci(df: DataFrame, **kwargs: Dict) -> DataFrame:
     return (
         df.pipe(set_alpha_and_adjust_preference, **kwargs)
         .assign(**{P_VALUE: lambda df: df.pipe(_p_value, **kwargs)})
-        .pipe(add_adjusted_p_and_is_significant, **kwargs) # remove?
-        .pipe(add_ci, **kwargs) # remove?
     )
 
 

--- a/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/confidence_computer.py
@@ -493,6 +493,7 @@ class ConfidenceComputer(ConfidenceComputerABC):
             if column is not None
             and (column != self._ordinal_group_column or final_expected_sample_size_column is None)
         ]
+        print('groups_except_ordinal: ' + str(groups_except_ordinal))
         n_comparisons = get_num_comparisons(
             comparison_df,
             self._correction_method,
@@ -524,6 +525,10 @@ class ConfidenceComputer(ConfidenceComputerABC):
             ),
             lambda df: _compute_comparisons(df, **kwargs),
         )
+        #comparison_df = (comparison_df.pipe(add_adjusted_p_and_is_significant, **kwargs)
+        #                              .pipe(add_ci, **kwargs)
+        #                              .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE]))
+
         return comparison_df
 
     def achieved_power(self, level_1, level_2, mde, alpha, groupby):
@@ -559,7 +564,7 @@ def _compute_comparisons(df: DataFrame, **kwargs: Dict) -> DataFrame:
         .assign(**{STD_ERR: confidence_computers[df[kwargs[METHOD]].values[0]].std_err(df, **kwargs)})
         .pipe(_add_p_value_and_ci, **kwargs)
         .pipe(_powered_effect_and_required_sample_size_from_difference_df, **kwargs)
-        .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE])
+        .pipe(_adjust_if_absolute, absolute=kwargs[ABSOLUTE]) # remove?
         .assign(**{PREFERENCE: lambda df: df[PREFERENCE].map(PREFERENCE_DICT)})
         .pipe(_add_variance_reduction_rate, **kwargs)
     )
@@ -584,8 +589,8 @@ def _add_p_value_and_ci(df: DataFrame, **kwargs: Dict) -> DataFrame:
     return (
         df.pipe(set_alpha_and_adjust_preference, **kwargs)
         .assign(**{P_VALUE: lambda df: df.pipe(_p_value, **kwargs)})
-        .pipe(add_adjusted_p_and_is_significant, **kwargs)
-        .pipe(add_ci, **kwargs)
+        .pipe(add_adjusted_p_and_is_significant, **kwargs) # remove?
+        .pipe(add_ci, **kwargs) # remove?
     )
 
 

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
@@ -127,7 +127,6 @@ def compute_sequential_adjusted_alpha(df: DataFrame, **kwargs: Dict[str, str]):
     ordinal_group_column = kwargs[ORDINAL_GROUP_COLUMN]
     n_comparisons = kwargs[NUMBER_OF_COMPARISONS]
 
-
     if not df.reset_index()[ordinal_group_column].is_unique:
         raise ValueError("Ordinal values cannot be duplicated")
 

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union, Dict
 
 import numpy as np
-from pandas import DataFrame, Series, set_option as pd_set_option
+from pandas import DataFrame, Series
 from scipy import optimize
 from scipy import stats as st
 
@@ -127,16 +127,6 @@ def compute_sequential_adjusted_alpha(df: DataFrame, **kwargs: Dict[str, str]):
     ordinal_group_column = kwargs[ORDINAL_GROUP_COLUMN]
     n_comparisons = kwargs[NUMBER_OF_COMPARISONS]
 
-    
-    #pd_set_option('display.max_columns', None)
-    #pd_set_option('display.max_rows', 100)
-    #pd_set_option('display.width', 200)
-    #print('denominator: ' + denominator)
-    #print('n_comparisons: ' + str(n_comparisons))
-    #print('ordinal group column: ' + ordinal_group_column)
-    #print('df before error')
-    #print(df)
-    #assert False, "dumb assert to make PyTest print my stuff" 
 
     if not df.reset_index()[ordinal_group_column].is_unique:
         raise ValueError("Ordinal values cannot be duplicated")

--- a/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
+++ b/spotify_confidence/analysis/frequentist/confidence_computers/z_test_computer.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union, Dict
 
 import numpy as np
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, set_option as pd_set_option
 from scipy import optimize
 from scipy import stats as st
 
@@ -126,6 +126,17 @@ def compute_sequential_adjusted_alpha(df: DataFrame, **kwargs: Dict[str, str]):
     final_expected_sample_size_column = kwargs[FINAL_EXPECTED_SAMPLE_SIZE]
     ordinal_group_column = kwargs[ORDINAL_GROUP_COLUMN]
     n_comparisons = kwargs[NUMBER_OF_COMPARISONS]
+
+    
+    #pd_set_option('display.max_columns', None)
+    #pd_set_option('display.max_rows', 100)
+    #pd_set_option('display.width', 200)
+    #print('denominator: ' + denominator)
+    #print('n_comparisons: ' + str(n_comparisons))
+    #print('ordinal group column: ' + ordinal_group_column)
+    #print('df before error')
+    #print(df)
+    #assert False, "dumb assert to make PyTest print my stuff" 
 
     if not df.reset_index()[ordinal_group_column].is_unique:
         raise ValueError("Ordinal values cannot be duplicated")

--- a/tests/frequentist/test_ztest.py
+++ b/tests/frequentist/test_ztest.py
@@ -206,6 +206,7 @@ class TestPoweredEffectContinuousMultipleMetricTypes(object):
         assert powered_effect[REQUIRED_SAMPLE_SIZE].isna()[0]
         assert powered_effect[REQUIRED_SAMPLE_SIZE].isna()[1]
         assert np.isclose(powered_effect[REQUIRED_SAMPLE_SIZE][2], 16487886, atol=100)
+
         assert np.isclose(powered_effect[REQUIRED_SAMPLE_SIZE][3], 3083846, atol=100)
 
 


### PR DESCRIPTION
We discovered that multiple correction methods other than Bonferroni did not apply any corrections. After troubleshooting it was discovered that this is due to the dataframe with comparisons being sent row by row to the functions handling the corrections. Thus `multipletests` was only run for one p-value at a time.

This PR fixes this so that `multipletests` gets the p-values from all of the conducted comparisons and is able to do multiple corrections using the supported methods. Also updated tests to include verifying that the adjusted p-values are correct for other correction methods than Bonferroni.